### PR TITLE
chore: enable Next.js cache components and migrate from `unstable_cache` to `"use cache"`

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import createMDX from "@next/mdx";
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+  cacheComponents: true,
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   transpilePackages: ["bsky-react-post"],
   // transpilePackages: ['@stylexjs/open-props'],

--- a/src/app/blog/atom.xml/route.ts
+++ b/src/app/blog/atom.xml/route.ts
@@ -1,7 +1,7 @@
-import { unstable_cache } from "next/cache";
 import { getFeed } from "../getFeed";
 
-export const GET = unstable_cache(async function get() {
+export const GET = async function get() {
+  "use cache";
   let feed;
   try {
     feed = await getFeed();
@@ -16,6 +16,6 @@ export const GET = unstable_cache(async function get() {
       "Content-Type": "application/atom+xml; charset=utf-8",
     },
   });
-});
+};
 
 export const dynamic = "force-static";

--- a/src/app/blog/feed.json/route.ts
+++ b/src/app/blog/feed.json/route.ts
@@ -1,7 +1,7 @@
-import { unstable_cache } from "next/cache";
 import { getFeed } from "../getFeed";
 
-export const GET = unstable_cache(async function get() {
+export const GET = async function get() {
+  "use cache";
   let feed;
   try {
     feed = await getFeed();
@@ -17,6 +17,6 @@ export const GET = unstable_cache(async function get() {
       "Content-Type": "application/json; charset=utf-8",
     },
   });
-});
+};
 
 export const dynamic = "force-static";

--- a/src/app/blog/feed.xml/route.ts
+++ b/src/app/blog/feed.xml/route.ts
@@ -1,7 +1,7 @@
-import { unstable_cache } from "next/cache";
 import { getFeed } from "../getFeed";
 
-export const GET = unstable_cache(async function get() {
+export const GET = async function get() {
+  "use cache";
   let feed;
   try {
     feed = await getFeed();
@@ -17,5 +17,5 @@ export const GET = unstable_cache(async function get() {
       "Content-Type": "application/xml; charset=utf-8",
     },
   });
-});
+};
 export const dynamic = "force-static";

--- a/src/app/blog/getFeed.ts
+++ b/src/app/blog/getFeed.ts
@@ -1,8 +1,7 @@
 import { Feed } from "feed";
 import { getBlogPosts } from "./getPosts";
-import { unstable_cache } from "next/cache";
-
-export const getFeed = unstable_cache(async function getFeed() {
+export async function getFeed() {
+  "use cache";
   const siteURL = "https://nmn.sh";
   const feedOptions = {
     title: "nmn.sh",
@@ -44,4 +43,4 @@ export const getFeed = unstable_cache(async function getFeed() {
     console.error(error);
     return feed;
   }
-});
+}

--- a/src/app/blog/getPosts.ts
+++ b/src/app/blog/getPosts.ts
@@ -1,6 +1,5 @@
 import fs from "fs/promises";
 import path from "path";
-import { unstable_cache } from "next/cache";
 import * as runtime from "react/jsx-runtime";
 import { evaluate } from "@mdx-js/mdx";
 
@@ -15,7 +14,8 @@ export type Config = {
   tags?: string[];
 };
 
-export const getBlogPosts = unstable_cache(async () => {
+export const getBlogPosts = async () => {
+  "use cache";
   const blogs = await fs.readdir(blogDir);
 
   // filter for only folders
@@ -59,4 +59,4 @@ export const getBlogPosts = unstable_cache(async () => {
     .sort((a, b) =>
       a.date != null && b.date != null ? b.date.localeCompare(a.date) : 0
     );
-});
+};


### PR DESCRIPTION
### Motivation
- Replace deprecated `unstable_cache` usage with the new Next.js cache semantics and correctly enable the cache components feature flag.
- Ensure blog feed generation and post-loading retain caching behavior with the supported API surface.

### Description
- Enable cache components by setting `cacheComponents: true` in `next.config.ts` instead of using the experimental flag.
- Remove `import { unstable_cache } from "next/cache"` and unwrap or convert wrapped functions into plain async functions that include the `"use cache"` directive.
- Update route handlers to export `GET` as async functions with `"use cache"` and keep `export const dynamic = "force-static"` for feeds. 
- Key files modified: `next.config.ts`, `src/app/blog/atom.xml/route.ts`, `src/app/blog/feed.json/route.ts`, `src/app/blog/feed.xml/route.ts`, `src/app/blog/getFeed.ts`, and `src/app/blog/getPosts.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986247cdf108321a5e87942872201e6)